### PR TITLE
RHMAP-10212 fix iOS build fails

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -25,5 +25,5 @@
         <allow-intent href="itms-apps:*" />
     </platform>
     <plugin name="cordova-plugin-whitelist" spec="https://github.com/apache/cordova-plugin-whitelist"/>
-    <plugin name="aerogear-cordova-push" spec="https://github.com/feedhenry/aerogear-cordova-push#no-dupe-permission"/>
+    <plugin name="aerogear-cordova-push" spec="https://github.com/aerogear/aerogear-cordova-push#3.0.x-cdv-droid411"/>
 </widget>


### PR DESCRIPTION
Updated aerogear-cordova-push plugin to use aerogear 3.0.x-cdv-droid411 branch as it has a good  libpush-sdk-1.1.1.a
