### PR TITLE
RHMAP-14102 - pushstarter-cordova-app doesn't download Roboto font

### DIFF
--- a/www/css/index.css
+++ b/www/css/index.css
@@ -13,7 +13,7 @@
  */
 
 /* Caution ios version in merges folder */
-@import url(http://fonts.googleapis.com/css?family=Roboto:400,500);
+@import url(https://fonts.googleapis.com/css?family=Roboto:400,500);
 * {
    margin: 0;
    padding: 0;


### PR DESCRIPTION
## Motivation
In index.css there is a link to http://fonts.googleapis.com/css?family=Roboto:400,500, but it can't be downloaded on iOS

## Result
Use https instead of http in the url.

## Jira
https://issues.jboss.org/browse/RHMAP-14102